### PR TITLE
Add GoTTY tool tests and docs

### DIFF
--- a/docs/cmd/tools/gotty/attach.md
+++ b/docs/cmd/tools/gotty/attach.md
@@ -1,0 +1,68 @@
+# gotty attach
+
+## Description
+
+The `attach` sub-command under the `tools gotty` command creates and starts a container that runs the [GoTTY](https://github.com/srl-labs/gotty-service) web terminal. GoTTY provides a browser based terminal which can be used to access your lab nodes via SSH.
+
+## Usage
+
+```
+containerlab tools gotty attach [flags]
+```
+
+## Flags
+
+### --lab | -l
+
+Name of the lab to attach the GoTTY container to.
+
+### --topology | -t
+
+Path to the topology file (`*.clab.yml`) that defines the lab. This flag can be used instead of `--lab`.
+
+### --name
+
+Name of the GoTTY container. If omitted it defaults to `clab-<labname>-gotty`.
+
+### --port | -p
+
+Port for the GoTTY web interface. Default is `8080`.
+
+### --username | -u
+
+Username used to authenticate to the GoTTY web terminal. Defaults to `admin`.
+
+### --password | -P
+
+Password used to authenticate to the GoTTY web terminal. Defaults to `admin`.
+
+### --shell | -s
+
+Shell to start inside the container. Defaults to `bash`.
+
+### --image | -i
+
+Container image used to run GoTTY. Defaults to `ghcr.io/srl-labs/network-multitool`.
+
+### --owner | -o
+
+Owner name to associate with the GoTTY container. If not provided it will be discovered automatically from environment variables.
+
+## Examples
+
+Attach a GoTTY container to a running lab:
+
+```bash
+❯ containerlab tools gotty attach -l mylab
+11:40:03 INFO Pulling image ghcr.io/srl-labs/network-multitool...
+11:40:03 INFO Creating GoTTY container clab-mylab-gotty on network 'clab-mylab'
+11:40:04 INFO GoTTY container clab-mylab-gotty started. Waiting for GoTTY service to initialize...
+11:40:09 INFO GoTTY web terminal successfully started url=http://HOST_IP:8080 username=admin password=admin
+```
+
+Once started, open the printed URL in a browser to access the terminal. From there you can connect to lab nodes using SSH for example:
+
+```
+ssh admin@clab-mylab-node1
+```
+

--- a/docs/cmd/tools/gotty/detach.md
+++ b/docs/cmd/tools/gotty/detach.md
@@ -1,0 +1,29 @@
+# gotty detach
+
+## Description
+
+The `detach` sub-command under the `tools gotty` command removes a GoTTY container from a lab network, terminating the web terminal session.
+
+## Usage
+
+```
+containerlab tools gotty detach [flags]
+```
+
+## Flags
+
+### --lab | -l
+
+Name of the lab where the GoTTY container is attached.
+
+### --topology | -t
+
+Path to the topology file (`*.clab.yml`) to derive the lab name if `--lab` is not provided.
+
+## Examples
+
+```bash
+❯ containerlab tools gotty detach -l mylab
+11:40:03 INFO Removing GoTTY container clab-mylab-gotty
+11:40:03 INFO GoTTY container clab-mylab-gotty removed successfully
+```

--- a/docs/cmd/tools/gotty/list.md
+++ b/docs/cmd/tools/gotty/list.md
@@ -1,0 +1,46 @@
+# gotty list
+
+## Description
+
+The `list` sub-command under the `tools gotty` command shows all active GoTTY containers. Information such as container name, network, state, IP address, port, web URL and owner are presented.
+
+## Usage
+
+```
+containerlab tools gotty list [flags]
+```
+
+## Flags
+
+### --format | -f
+
+Output format for the command. Either `table` (default) or `json`.
+
+## Examples
+
+List GoTTY containers in table format:
+
+```bash
+❯ containerlab tools gotty list
+NAME              NETWORK     STATUS   IPv4 ADDRESS   PORT   WEB URL                OWNER
+clab-mylab-gotty  clab-mylab  running  172.20.20.5    8080   http://HOST_IP:8080    alice
+```
+
+List GoTTY containers in JSON format:
+
+```bash
+❯ containerlab tools gotty list -f json
+[
+  {
+    "name": "clab-mylab-gotty",
+    "network": "clab-mylab",
+    "state": "running",
+    "ipv4_address": "172.20.20.5",
+    "port": 8080,
+    "web_url": "http://HOST_IP:8080",
+    "owner": "alice"
+  }
+]
+```
+
+If no containers are running the command prints `No active GoTTY containers found` (or `[]` in JSON mode).

--- a/docs/cmd/tools/gotty/reattach.md
+++ b/docs/cmd/tools/gotty/reattach.md
@@ -1,0 +1,26 @@
+# gotty reattach
+
+## Description
+
+The `reattach` sub-command under the `tools gotty` command removes any existing GoTTY container from a lab and then creates a new one with the same parameters. This is useful for refreshing the web terminal session.
+
+## Usage
+
+```
+containerlab tools gotty reattach [flags]
+```
+
+## Flags
+
+Same as the `attach` command (`--lab`, `--name`, `--port`, `--username`, `--password`, `--shell`, `--image`, `--owner`).
+
+## Examples
+
+```bash
+❯ containerlab tools gotty reattach -l mylab
+11:40:03 INFO Removing existing GoTTY container clab-mylab-gotty if present...
+11:40:03 INFO Pulling image ghcr.io/srl-labs/network-multitool...
+11:40:04 INFO Creating new GoTTY container clab-mylab-gotty on network 'clab-mylab'
+11:40:05 INFO GoTTY container clab-mylab-gotty started. Waiting for GoTTY service to initialize...
+11:40:10 INFO GoTTY web terminal successfully reattached url=http://HOST_IP:8080 username=admin password=admin
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,11 @@ nav:
               - detach: cmd/tools/sshx/detach.md
               - reattach: cmd/tools/sshx/reattach.md
               - list: cmd/tools/sshx/list.md
+          - gotty:
+              - attach: cmd/tools/gotty/attach.md
+              - detach: cmd/tools/gotty/detach.md
+              - reattach: cmd/tools/gotty/reattach.md
+              - list: cmd/tools/gotty/list.md
       - version:
           - cmd/version/index.md
           - check: cmd/version/check.md

--- a/tests/01-smoke/23-tools-gotty.robot
+++ b/tests/01-smoke/23-tools-gotty.robot
@@ -1,0 +1,125 @@
+*** Comments ***
+This test suite verifies the functionality of the GoTTY web terminal operations:
+- Attaching a GoTTY container using lab name (-l) parameter
+- Attaching a GoTTY container using topology file (-t) parameter
+- Testing reattach functionality
+- Listing active GoTTY containers
+- Detaching a GoTTY container from a lab network
+
+*** Settings ***
+Library             OperatingSystem
+Library             String
+Resource            ../common.robot
+
+Suite Teardown      Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
+
+*** Variables ***
+${runtime}          docker
+${lab_name}         2-linux-nodes
+${topo}             ${CURDIR}/01-linux-nodes.clab.yml
+${gotty_container}   clab-${lab_name}-gotty
+
+*** Test Cases ***
+Deploy Test Lab
+    [Documentation]    Deploy the test lab for GoTTY tests
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+Attach GoTTY Using Lab Name Parameter
+    [Documentation]    Test attaching GoTTY container using the -l (lab name) parameter
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty attach -l ${lab_name}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    GoTTY container ${gotty_container} started
+    Should Contain    ${output}    GoTTY web terminal successfully started
+
+List GoTTY Containers
+    [Documentation]    Test listing GoTTY containers
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty list
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    ${gotty_container}
+    Should Contain    ${output}    running
+
+List GoTTY Containers JSON Format
+    [Documentation]    Test listing GoTTY containers in JSON format
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty list --format json
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    "${gotty_container}"
+    Should Contain    ${output}    "running"
+
+Detach GoTTY Using Lab Name Parameter
+    [Documentation]    Test detaching GoTTY container using the -l (lab name) parameter
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty detach -l ${lab_name}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    GoTTY container ${gotty_container} removed successfully
+
+    # Verify container is removed
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${runtime} ps -a | grep ${gotty_container} || true
+    Log    ${output}
+    Should Not Contain    ${output}    ${gotty_container}
+
+Attach GoTTY Using Topology File Parameter
+    [Documentation]    Test attaching GoTTY container using the -t (topology file) parameter
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty attach -t ${topo}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    GoTTY container ${gotty_container} started
+    Should Contain    ${output}    GoTTY web terminal successfully started
+
+    # Clean up this container before the next test
+    ${clean_rc}=    Run And Return Rc
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty detach -l ${lab_name}
+    Log    Cleanup return code: ${clean_rc}
+    Sleep    2s
+
+# No read-only functionality for GoTTY; skip analogous test
+
+    # Clean up this container before the next test
+    ${clean_rc}=    Run And Return Rc
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty detach -l ${lab_name}
+    Log    Cleanup return code: ${clean_rc}
+    Sleep    2s
+
+Test GoTTY Reattach Functionality
+    [Documentation]    Test reattaching GoTTY container (detach+attach)
+    # First attach a GoTTY container
+    ${rc1}    ${output1}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty attach -l ${lab_name}
+    Log    ${output1}
+    Should Be Equal As Integers    ${rc1}    0
+    Should Contain    ${output1}    GoTTY web terminal successfully started
+
+    # Sleep to ensure container is fully operational
+    Sleep    3s
+
+    # Now reattach the container
+    ${rc2}    ${output2}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty reattach -l ${lab_name}
+    Log    ${output2}
+    Should Be Equal As Integers    ${rc2}    0
+    Should Contain    ${output2}    GoTTY web terminal successfully reattached
+
+    # Clean up this container before the next test
+    ${clean_rc}=    Run And Return Rc
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty detach -l ${lab_name}
+    Log    Cleanup return code: ${clean_rc}
+    Sleep    2s
+
+Verify GoTTY Container List Is Empty
+    [Documentation]    Test that no GoTTY containers are listed after detaching
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools gotty list
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${output}    ${gotty_container}


### PR DESCRIPTION
## Summary
- add Robot Framework tests for `tools gotty`
- document `gotty` attach, detach, list and reattach commands
- include gotty pages in MkDocs navigation

## Testing
- `make lint` *(fails: can't load config)*
- `make test` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
