### PR TITLE
Fix overlay code class for highlighting

### DIFF
--- a/docs/javascripts/extra.js
+++ b/docs/javascripts/extra.js
@@ -67,7 +67,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var overlay = document.querySelector(".code-overlay");
       if (!overlay) {
         overlay = document.createElement("div");
-        overlay.className = "md-typeset code-overlay";
+        overlay.className = container.className + " md-typeset code-overlay";
         var clone = pre.cloneNode(true);
         overlay.appendChild(clone);
         document.body.appendChild(overlay);


### PR DESCRIPTION
## Summary
- include parent container classes when opening code overlay

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6852f6c0338c83309a413aa93aa6e8bb